### PR TITLE
3 add sensible support for lifetimes over underlying reader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 /target
 /Cargo.lock
+rusty-tags.vi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chisel-decoders"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 authors = ["Jonny Coombes <jcoombes@jcs-software.co.uk>"]
 rust-version = "1.56"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 [![crates.io](https://img.shields.io/crates/v/chisel-decoders.svg)](https://crates.io/crates/chisel-decoders)
 
+[![crates.io](https://img.shields.io/crates/l/chisel-decoders.svg)](https://crates.io/crates/chisel-decoders)
+
  ## Overview
 
  This repository contains a very simple, lean implementation of a decoder that will consume `u8` bytes from a given
@@ -88,10 +90,10 @@
 
 ## Building and Testing
 
-As you would expect, just `cargo build` in order to build the crate.  
+As you would expect, just `cargo build` in order to build the crate.
 
 ## Suggestions and Requests
 
-If you have any suggestions, requests or even just comments relating to this crate, then please just add an issue and 
+If you have any suggestions, requests or even just comments relating to this crate, then please just add an issue and
 I'll try and take a look when I get change.  Please feel free to fork this repo if you want to utilise/modify this code
 in any of your own work.

--- a/benches/decoding.rs
+++ b/benches/decoding.rs
@@ -1,17 +1,19 @@
+use chisel_decoders::utf8::Utf8Decoder;
+use criterion::{criterion_group, criterion_main, Criterion};
+use pprof::criterion::{Output, PProfProfiler};
 use std::fs::File;
 use std::io::BufReader;
-use criterion::{criterion_group, criterion_main, Criterion};
-use chisel_decoders::utf8::Utf8Decoder;
-use pprof::criterion::{Output, PProfProfiler};
 
 macro_rules! build_decode_benchmark {
     ($func : tt, $filename : expr) => {
         fn $func() {
             let f = File::open(format!("fixtures/json/bench/{}.json", $filename)).unwrap();
-            let reader = BufReader::new(f);
-            let mut decoder = Utf8Decoder::new(reader);
+            let mut reader = BufReader::new(f);
+            let mut decoder = Utf8Decoder::new(&mut reader);
             let mut _count = 0;
-            while decoder.decode_next().is_ok() { _count+= 1}
+            while decoder.decode_next().is_ok() {
+                _count += 1
+            }
         }
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,15 +16,15 @@
 //!
 //! ### Create from a slice
 //!
-//! Just wrap your array in a reader, and then plug it into a new instance of `Utf8Decoder`:
+//! Just wrap your array in a `mut` reader, and then plug it into a new instance of `Utf8Decoder`:
 //!
 //! ```rust
 //!     # use std::io::BufReader;
 //!     # use chisel_decoders::utf8::Utf8Decoder;
 //!
 //!     let buffer: &[u8] = &[0x10, 0x12, 0x23, 0x12];
-//!     let reader = BufReader::new(buffer);
-//!     let _decoder = Utf8Decoder::new(reader);
+//!     let mut reader = BufReader::new(buffer);
+//!     let _decoder = Utf8Decoder::new(&mut reader);
 //! ```
 //!
 //! ### Create from a file
@@ -39,8 +39,8 @@
 //!
 //!     let path = PathBuf::from("./Cargo.toml");
 //!     let f = File::open(path);
-//!     let reader = BufReader::new(f.unwrap());
-//!     let _decoder = Utf8Decoder::new(reader);
+//!     let mut reader = BufReader::new(f.unwrap());
+//!     let _decoder = Utf8Decoder::new(&mut reader);
 //! ```
 //! ### Consuming `char`s
 //!
@@ -54,8 +54,8 @@
 //!
 //!     let path = PathBuf::from("./Cargo.toml");
 //!     let f = File::open(path);
-//!     let reader = BufReader::new(f.unwrap());
-//!     let mut decoder = Utf8Decoder::new(reader);
+//!     let mut reader = BufReader::new(f.unwrap());
+//!     let mut decoder = Utf8Decoder::new(&mut reader);
 //!     loop {
 //!         let result = decoder.decode_next();
 //!         if result.is_err() {
@@ -73,8 +73,8 @@
 //!
 //!     let path = PathBuf::from("./Cargo.toml");
 //!     let f = File::open(path);
-//!     let reader = BufReader::new(f.unwrap());
-//!     let decoder = Utf8Decoder::new(reader);
+//!     let mut reader = BufReader::new(f.unwrap());
+//!     let decoder = Utf8Decoder::new(&mut reader);
 //!     for c in decoder {
 //!        println!("char: {}", c)
 //!     }


### PR DESCRIPTION
Modified the `Utf8Decoder` implementation to take a mut ref to the underlying buffer